### PR TITLE
Update TS installation docs to use `pnpm exec` instead of `pnpx`

### DIFF
--- a/fern/01-guide/02-languages/typescript.mdx
+++ b/fern/01-guide/02-languages/typescript.mdx
@@ -38,7 +38,7 @@ To set up BAML with Typescript do the following:
         ```
         
         ```bash pnpm
-        pnpx baml-cli init
+        pnpm exec baml-cli init
         ```
 
         ```bash yarn


### PR DESCRIPTION
[`pnpx` has been deprecated](https://github.com/pnpm/pnpm/pull/3652) in favor of `pnpm exec` and `pnpm dlx`. 

This PR modifies the installation docs for Typescript / pnpm to use `pnpm exec` instead of `pnpx`. `exec` is favored over `dlx` in this instance since the `baml-cli` command is installed in the local `node_modules/.bin`.